### PR TITLE
CCX-5116 - Terraform cannot destroy a failed datastore

### DIFF
--- a/internal/ccx/api/api.go
+++ b/internal/ccx/api/api.go
@@ -7,6 +7,20 @@ import (
 
 // HttpClient is used to make requests to the ccx api
 type HttpClient interface {
+	// Do sends a request to the API and returns the response
+	// errors returned are:
+	// - ccx.RequestEncodingErr (if body encoding fails)
+	// - ccx.RequestInitializationErr (if request creation fails)
+	// - ccx.RequestSendingErr (if request sending fails)
+	// - ccx.ResourceNotFoundErr (if API returns 404)
+	// - ccx.ApiErr (if API returns 4xx or 5xx)
 	Do(ctx context.Context, method, path string, body any) (*http.Response, error)
+
+	// Get sends a GET request to the API and decodes the response into target
+	// errors returned are:
+	// - ccx.RequestInitializationErr (if request creation fails)
+	// - ccx.RequestSendingErr (if request sending fails)
+	// - ccx.ResourceNotFoundErr (if API returns 404)
+	// - ccx.ApiErr (if API returns 4xx or 5xx)
 	Get(ctx context.Context, path string, target any) error
 }

--- a/internal/ccx/api/datastore_delete.go
+++ b/internal/ccx/api/datastore_delete.go
@@ -6,12 +6,14 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/severalnines/terraform-provider-ccx/internal/ccx"
 )
 
 func (svc *DatastoreService) Delete(ctx context.Context, id string) error {
 	_, err := svc.client.Do(ctx, http.MethodDelete, "/api/prov/api/v2/cluster"+"/"+id, nil)
 	if errors.Is(err, ccx.ResourceNotFoundErr) {
+		tflog.Warn(ctx, "deleting datastore: not found", map[string]interface{}{"id": id})
 		return nil
 	} else if err != nil {
 		return fmt.Errorf("deleting datastore: %w", err)

--- a/internal/ccx/api/datastore_firewall.go
+++ b/internal/ccx/api/datastore_firewall.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 
 	"github.com/severalnines/terraform-provider-ccx/internal/ccx"
-	"github.com/severalnines/terraform-provider-ccx/internal/lib"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -76,17 +75,9 @@ func firewallsDiff(have, want []ccx.FirewallRule) (create, del []ccx.FirewallRul
 }
 
 func (svc *DatastoreService) CreateFirewallRule(ctx context.Context, storeID string, firewall ccx.FirewallRule) error {
-	res, err := svc.client.Do(ctx, http.MethodPost, "/api/firewall/api/v1/firewall/"+storeID, firewall)
+	_, err := svc.client.Do(ctx, http.MethodPost, "/api/firewall/api/v1/firewall/"+storeID, firewall)
 	if err != nil {
-		return errors.Join(ccx.RequestSendingErr, err)
-	}
-
-	if res.StatusCode == http.StatusBadRequest {
-		return lib.ErrorFromErrorResponse(res.Body)
-	}
-
-	if res.StatusCode != http.StatusCreated {
-		return fmt.Errorf("%w: status = %d", lib.ErrorFromErrorResponse(res.Body), res.StatusCode)
+		return err
 	}
 
 	return nil
@@ -111,17 +102,11 @@ func (svc *DatastoreService) CreateFirewallRules(ctx context.Context, storeID st
 }
 
 func (svc *DatastoreService) DeleteFirewallRule(ctx context.Context, storeID string, firewall ccx.FirewallRule) error {
-	res, err := svc.client.Do(ctx, http.MethodDelete, "/api/firewall/api/v1/firewall/"+storeID, firewall)
-	if err != nil {
-		return errors.Join(ccx.RequestSendingErr, err)
-	}
-
-	if res.StatusCode == http.StatusBadRequest {
-		return lib.ErrorFromErrorResponse(res.Body)
-	}
-
-	if res.StatusCode != http.StatusAccepted {
-		return fmt.Errorf("%w: status = %d", lib.ErrorFromErrorResponse(res.Body), res.StatusCode)
+	_, err := svc.client.Do(ctx, http.MethodDelete, "/api/firewall/api/v1/firewall/"+storeID, firewall)
+	if errors.Is(err, ccx.ResourceNotFoundErr) {
+		return nil
+	} else if err != nil {
+		return fmt.Errorf("deleting rule (source=%s, description=%s): %w", firewall.Source, firewall.Description, err)
 	}
 
 	return nil

--- a/internal/ccx/api/datastore_firewall.go
+++ b/internal/ccx/api/datastore_firewall.go
@@ -8,6 +8,7 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/severalnines/terraform-provider-ccx/internal/ccx"
 	"golang.org/x/sync/errgroup"
 )
@@ -104,6 +105,9 @@ func (svc *DatastoreService) CreateFirewallRules(ctx context.Context, storeID st
 func (svc *DatastoreService) DeleteFirewallRule(ctx context.Context, storeID string, firewall ccx.FirewallRule) error {
 	_, err := svc.client.Do(ctx, http.MethodDelete, "/api/firewall/api/v1/firewall/"+storeID, firewall)
 	if errors.Is(err, ccx.ResourceNotFoundErr) {
+		tflog.Warn(ctx, "deleting firewall rule: not found", map[string]any{
+			"source": firewall.Source, "description": firewall.Description,
+		})
 		return nil
 	} else if err != nil {
 		return fmt.Errorf("deleting rule (source=%s, description=%s): %w", firewall.Source, firewall.Description, err)

--- a/internal/ccx/api/datastore_maintenance.go
+++ b/internal/ccx/api/datastore_maintenance.go
@@ -2,12 +2,10 @@ package api
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/http"
 
 	"github.com/severalnines/terraform-provider-ccx/internal/ccx"
-	"github.com/severalnines/terraform-provider-ccx/internal/lib"
 )
 
 func (svc *DatastoreService) SetMaintenanceSettings(ctx context.Context, storeID string, settings ccx.MaintenanceSettings) error {
@@ -19,17 +17,9 @@ func (svc *DatastoreService) SetMaintenanceSettings(ctx context.Context, storeID
 		},
 	}
 
-	res, err := svc.client.Do(ctx, http.MethodPatch, "/api/prov/api/v2/cluster/"+storeID, ur)
+	_, err := svc.client.Do(ctx, http.MethodPatch, "/api/prov/api/v2/cluster/"+storeID, ur)
 	if err != nil {
-		return errors.Join(ccx.RequestSendingErr, err)
-	}
-
-	if res.StatusCode == http.StatusBadRequest {
-		return lib.ErrorFromErrorResponse(res.Body)
-	}
-
-	if res.StatusCode != http.StatusOK {
-		return fmt.Errorf("%w: status = %d", ccx.ResponseStatusFailedErr, res.StatusCode)
+		return fmt.Errorf("setting maintenance settings: %w", err)
 	}
 
 	return nil

--- a/internal/ccx/api/jobs.go
+++ b/internal/ccx/api/jobs.go
@@ -56,7 +56,7 @@ func (svc JobsService) Await(ctx context.Context, storeID string, job ccx.JobTyp
 
 		status, err = svc.GetStatus(ctx, storeID, job)
 
-		if err != nil && !errors.Is(err, ccx.ResourceNotFoundErr) { // ignore not found errors, give it some time to appear
+		if err != nil {
 			return ccx.JobStatusUnknown, fmt.Errorf("getting job status: %w", err)
 		}
 

--- a/internal/ccx/api/jobs.go
+++ b/internal/ccx/api/jobs.go
@@ -56,7 +56,7 @@ func (svc JobsService) Await(ctx context.Context, storeID string, job ccx.JobTyp
 
 		status, err = svc.GetStatus(ctx, storeID, job)
 
-		if err != nil {
+		if err != nil && !errors.Is(err, ccx.ResourceNotFoundErr) { // ignore not found errors, give it some time to appear
 			return ccx.JobStatusUnknown, fmt.Errorf("getting job status: %w", err)
 		}
 

--- a/internal/ccx/api/parametergroup.go
+++ b/internal/ccx/api/parametergroup.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/severalnines/terraform-provider-ccx/internal/ccx"
 	"github.com/severalnines/terraform-provider-ccx/internal/lib"
 )
@@ -94,6 +95,7 @@ func (svc *ParameterGroupService) Update(ctx context.Context, p ccx.ParameterGro
 func (svc *ParameterGroupService) Delete(ctx context.Context, id string) error {
 	_, err := svc.client.Do(ctx, http.MethodDelete, "/api/db-configuration/v1/parameter-groups/"+id, nil)
 	if errors.Is(err, ccx.ResourceNotFoundErr) {
+		tflog.Warn(ctx, "deleting parameter group: not found", map[string]interface{}{"id": id})
 		return nil
 	} else if err != nil {
 		return fmt.Errorf("deleting parameter group: %w", err)

--- a/internal/ccx/api/vpc_create.go
+++ b/internal/ccx/api/vpc_create.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/http"
 
@@ -33,15 +32,7 @@ func (svc *VpcService) Create(ctx context.Context, vpc ccx.VPC) (*ccx.VPC, error
 
 	res, err := svc.httpcli.Do(ctx, http.MethodPost, "/api/vpc/api/v2/vpcs", cr)
 	if err != nil {
-		return nil, errors.Join(ccx.RequestSendingErr, err)
-	}
-
-	if res.StatusCode == http.StatusBadRequest {
-		return nil, lib.ErrorFromErrorResponse(res.Body)
-	}
-
-	if res.StatusCode != http.StatusCreated {
-		return nil, fmt.Errorf("%w: status = %d", ccx.ResponseStatusFailedErr, res.StatusCode)
+		return nil, fmt.Errorf("creating vpc: %w", err)
 	}
 
 	var rs vpcResponse

--- a/internal/ccx/api/vpc_delete.go
+++ b/internal/ccx/api/vpc_delete.go
@@ -10,13 +10,11 @@ import (
 )
 
 func (svc *VpcService) Delete(ctx context.Context, id string) error {
-	res, err := svc.httpcli.Do(ctx, http.MethodDelete, "/api/vpc/api/v2/vpcs"+"/"+id, nil)
-	if err != nil {
-		return errors.Join(ccx.RequestSendingErr, err)
-	}
-
-	if res.StatusCode != http.StatusAccepted {
-		return fmt.Errorf("%w: status = %d", ccx.ResponseStatusFailedErr, res.StatusCode)
+	_, err := svc.httpcli.Do(ctx, http.MethodDelete, "/api/vpc/api/v2/vpcs"+"/"+id, nil)
+	if errors.Is(err, ccx.ResourceNotFoundErr) {
+		return nil
+	} else if err != nil {
+		return fmt.Errorf("deleting vpc: %w", err)
 	}
 
 	return nil

--- a/internal/ccx/api/vpc_delete.go
+++ b/internal/ccx/api/vpc_delete.go
@@ -6,12 +6,14 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/severalnines/terraform-provider-ccx/internal/ccx"
 )
 
 func (svc *VpcService) Delete(ctx context.Context, id string) error {
 	_, err := svc.httpcli.Do(ctx, http.MethodDelete, "/api/vpc/api/v2/vpcs"+"/"+id, nil)
 	if errors.Is(err, ccx.ResourceNotFoundErr) {
+		tflog.Warn(ctx, "deleting vpc: not found", map[string]interface{}{"id": id})
 		return nil
 	} else if err != nil {
 		return fmt.Errorf("deleting vpc: %w", err)

--- a/internal/ccx/errors.go
+++ b/internal/ccx/errors.go
@@ -27,8 +27,11 @@ var (
 	// ResourceNotFoundErr occurs when trying to get a resource that does not exist
 	ResourceNotFoundErr = errors.New("resource not found")
 
-	// ResourcesLoadFailedErr occurs when trying to load resources fails
-	ResourcesLoadFailedErr = errors.New("failed to load resources")
+	// AllocatingAZsErr occurs when failing to allocate availability zones
+	AllocatingAZsErr = errors.New("allocating availability zones")
+
+	// ApiErr occurs when an error is returned from the api, typically when status code is 4xx or 5xx
+	ApiErr = errors.New("api error")
 
 	// UpdateNotSupportedErr occurs when trying to update a resource which might be destructive if attempted
 	UpdateNotSupportedErr = errors.New("updates for this resource are not supported")
@@ -36,14 +39,8 @@ var (
 	// AuthenticationFailedErr indicates failure to authenticate with the api server
 	AuthenticationFailedErr = errors.New("authentication failed")
 
-	// CreateFailedErr indicates failure to create a resource
-	CreateFailedErr = errors.New("failed to create resource")
-
 	// CreateFailedReadErr indicates failure to read a newly created resource. The resource may exist, but we have the id and terraform can possibly read it on next apply.
 	CreateFailedReadErr = errors.New("reading newly created resource failed")
-
-	// ParametersErr indicates failure to configure parameters
-	ParametersErr = errors.New("failed to configure parameters")
 
 	// FirewallRulesErr indicates failure to configure firewall rules
 	FirewallRulesErr = errors.New("failed to configure firewall rules")

--- a/internal/lib/http_test.go
+++ b/internal/lib/http_test.go
@@ -1,0 +1,65 @@
+package lib
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestErrorResponse_Error(t *testing.T) {
+	tests := []struct {
+		name    string
+		Code    json.Number
+		Err     string
+		ErrLong string
+		status  int
+		want    string
+	}{
+		{
+			name:    "Error with code and short error",
+			Code:    "1337",
+			Err:     "datastore does not exist",
+			ErrLong: "",
+			status:  http.StatusNotFound,
+			want:    "datastore does not exist (code: 1337, response: 404 - Not Found)",
+		},
+		{
+			name:    "Error with long error",
+			Code:    "",
+			Err:     "",
+			ErrLong: "failed to connect to database",
+			status:  http.StatusInternalServerError,
+			want:    "failed to connect to database (response: 500 - Internal Server Error)",
+		},
+		{
+			name:    "Error with code and long error",
+			Code:    "B9d",
+			Err:     "",
+			ErrLong: "something went wrong",
+			status:  http.StatusInternalServerError,
+			want:    "something went wrong (code: B9d, response: 500 - Internal Server Error)",
+		},
+		{
+			name:    "Error with no code and no error message",
+			Code:    "",
+			Err:     "",
+			ErrLong: "",
+			status:  http.StatusUnauthorized,
+			want:    "an error occurred (response: 401 - Unauthorized)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := ErrorResponse{
+				Code:    tt.Code,
+				Err:     tt.Err,
+				ErrLong: tt.ErrLong,
+				status:  tt.status,
+			}
+			assert.Equalf(t, tt.want, r.Error(), "Error()")
+		})
+	}
+}

--- a/resources/parametergroup.go
+++ b/resources/parametergroup.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -81,7 +82,10 @@ func (r *ParameterGroup) Read(ctx context.Context, d *schema.ResourceData, _ any
 	id := d.Id()
 
 	p, err := r.svc.Read(ctx, id)
-	if err != nil {
+	if errors.Is(err, ccx.ResourceNotFoundErr) {
+		d.SetId("")
+		return nil
+	} else if err != nil {
 		return diag.FromErr(err)
 	}
 


### PR DESCRIPTION
- Moved API error handling to the HttpClient
- Http Status Codes in the >= 400 range are treated as errors, the error is parsed from the response and returned